### PR TITLE
Allow passing arguments to JacketConsole.exe. Resolves #10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-p 9117` - the port(s)
 * `-v /config` - where Jackett should store its config file.
 * `-v /downloads` - Path to torrent blackhole
-* `-e ARGS` - Optionally specify additional arguments to be passed. EG. `--ProxyConnection 10.0.0.100:1234`
+* `-e RUN_OPTS` - Optionally specify additional arguments to be passed. EG. `--ProxyConnection 10.0.0.100:1234`
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone EG. Europe/London

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-p 9117` - the port(s)
 * `-v /config` - where Jackett should store its config file.
 * `-v /downloads` - Path to torrent blackhole
+* `-e ARGS` - Optionally specify additional arguments to be passed. EG. `--ProxyConnection 10.0.0.100:1234`
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone EG. Europe/London

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe
+	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe $ARGS

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe $ARGS
+	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe "${RUN_OPTS}"


### PR DESCRIPTION
Give more flexibility and allow passing arguments to Jackett by setting the ARGS environment variable. 

This allows, for example, specifying a proxy: "-j 10.0.0.100:1234"