### PR TITLE
chown -R root:root for Jackett files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN \
  /tmp/jacket.tar.gz -C \
 	/app/Jackett --strip-components=1 && \
  echo "**** fix for host id mapping error ****" && \
- chown root:root /app/Jackett && \
+ chown -R root:root /app/Jackett && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \


### PR DESCRIPTION
Add recursive to chown command to fix host id mapping error (#42)

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

