### PR TITLE
Remove aggressive chowns, cleanup Dockerfile #93

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG JACKETT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
-
-# arch settings, uncomment as neccesary
-ARG JACKETT_ARCH="LinuxAMDx64"
-# ARG JACKETT_ARCH="LinuxARM32"
-# ARG JACKETT_ARCH="LinuxARM64"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,7 +29,7 @@ RUN \
  fi && \
  curl -o \
  /tmp/jacket.tar.gz -L \
-	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.${JACKETT_ARCH}.tar.gz" && \
+	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.LinuxAMDx64.tar.gz" && \
  tar xf \
  /tmp/jacket.tar.gz -C \
 	/app/Jackett --strip-components=1 && \
@@ -51,5 +46,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-VOLUME /config /downloads
+VOLUME /config
 EXPOSE 9117

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,12 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG JACKETT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
-
-# arch settings, uncomment as neccesary
-# ARG JACKETT_ARCH="LinuxAMDx64"
-# ARG JACKETT_ARCH="LinuxARM32"
-ARG JACKETT_ARCH="LinuxARM64"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,7 +29,7 @@ RUN \
  fi && \
  curl -o \
  /tmp/jacket.tar.gz -L \
-	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.${JACKETT_ARCH}.tar.gz" && \
+	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.LinuxARM64.tar.gz" && \
  tar xf \
  /tmp/jacket.tar.gz -C \
 	/app/Jackett --strip-components=1 && \
@@ -51,5 +46,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-VOLUME /config /downloads
+VOLUME /config
 EXPOSE 9117

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,12 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG JACKETT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
-
-# arch settings, uncomment as neccesary
-# ARG JACKETT_ARCH="LinuxAMDx64"
-ARG JACKETT_ARCH="LinuxARM32"
-# ARG JACKETT_ARCH="LinuxARM64"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,7 +29,7 @@ RUN \
  fi && \
  curl -o \
  /tmp/jacket.tar.gz -L \
-	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.${JACKETT_ARCH}.tar.gz" && \
+	"https://github.com/Jackett/Jackett/releases/download/${JACKETT_RELEASE}/Jackett.Binaries.LinuxARM32.tar.gz" && \
  tar xf \
  /tmp/jacket.tar.gz -C \
 	/app/Jackett --strip-components=1 && \
@@ -51,5 +46,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-VOLUME /config /downloads
+VOLUME /config
 EXPOSE 9117

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **31.12.19:** - Remove agressive startup chowning.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **10.03.19:** - Switch to net-core builds of jackett, not dependant on mono and smaller images.
 * **11.02.19:** - Add pipeline logic and multi arch.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,6 +58,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "31.12.19:", desc: "Remove agressive startup chowning." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "10.03.19:", desc: "Switch to net-core builds of jackett, not dependant on mono and smaller images." }
   - { date: "11.02.19:", desc: "Add pipeline logic and multi arch." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,6 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 chown -R abc:abc \
-	/app \
-	/config \
-	/downloads
+	/config


### PR DESCRIPTION
Ref: https://github.com/linuxserver/docker-jackett/issues/93

App definitely does not need to be , this would also pull any chowning of /downloads which really should be managed by the user externally. 