### PR TITLE
Enable auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ docker create \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Europe/London \
+  -e AUTO_UPDATE=true `#optional` \
   -e RUN_OPTS=<run options here> `#optional` \
   -p 9117:9117 \
   -v <path to data>:/config \
@@ -99,6 +100,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
+      - AUTO_UPDATE=true #optional
       - RUN_OPTS=<run options here> #optional
     volumes:
       - <path to data>:/config
@@ -118,6 +120,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
+| `-e AUTO_UPDATE=true` | Allow Jackett to update inside of the container (currently recommended by Jacket) |
 | `-e RUN_OPTS=<run options here>` | Optionally specify additional arguments to be passed. EG. `--ProxyConnection=10.0.0.100:1234`. |
 | `-v /config` | Where Jackett should store its config file. |
 | `-v /downloads` | Path to torrent blackhole. |
@@ -227,6 +230,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.05.20:** - Allow user to optionally enable auto updates.
 * **31.12.19:** - Remove agressive startup chowning.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **10.03.19:** - Switch to net-core builds of jackett, not dependant on mono and smaller images.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
-| `-e AUTO_UPDATE=true` | Allow Jackett to update inside of the container (currently recommended by Jacket) |
+| `-e AUTO_UPDATE=true` | Allow Jackett to update inside of the container (currently recommended by Jackett and enabled by default) |
 | `-e RUN_OPTS=<run options here>` | Optionally specify additional arguments to be passed. EG. `--ProxyConnection=10.0.0.100:1234`. |
 | `-v /config` | Where Jackett should store its config file. |
 | `-v /downloads` | Path to torrent blackhole. |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,7 +40,7 @@ cap_add_param: false
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "AUTO_UPDATE", env_value: "true", desc: "Allow Jackett to update inside of the container (currently recommended by Jacket)" }
+  - { env_var: "AUTO_UPDATE", env_value: "true", desc: "Allow Jackett to update inside of the container (currently recommended by Jackett and enabled by default)" }
   - { env_var: "RUN_OPTS", env_value: "<run options here>", desc: "Optionally specify additional arguments to be passed. EG. `--ProxyConnection=10.0.0.100:1234`." }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ cap_add_param: false
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
+  - { env_var: "AUTO_UPDATE", env_value: "true", desc: "Allow Jackett to update inside of the container (currently recommended by Jacket)" }
   - { env_var: "RUN_OPTS", env_value: "<run options here>", desc: "Optionally specify additional arguments to be passed. EG. `--ProxyConnection=10.0.0.100:1234`." }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
@@ -57,6 +58,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "24.05.20:", desc: "Allow user to optionally enable auto updates." }
   - { date: "31.12.19:", desc: "Remove agressive startup chowning." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "10.03.19:", desc: "Switch to net-core builds of jackett, not dependant on mono and smaller images." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
 
 chown -R abc:abc \
-	/config 
+	/app/Jackett \
+	/config

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 chown -R abc:abc \
-	/app/Jackett \
 	/config
+
+if [ "${AUTO_UPDATE}" == "true" ]; then
+	chown -R abc:abc \
+		/app/Jackett
+fi

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,7 +3,7 @@
 chown -R abc:abc \
 	/config
 
-if [ "${AUTO_UPDATE}" == "true" ]; then
+if [ -z ${AUTO_UPDATE+x} ] || [ "${AUTO_UPDATE}" == "true" ]; then
 	chown -R abc:abc \
 		/app/Jackett
 fi

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,4 +1,10 @@
 #!/usr/bin/with-contenv bash
 
+if [ "${AUTO_UPDATE}" == "true" ]; then
+	COMMAND="/app/Jackett/jackett_launcher.sh"
+else
+	COMMAND="/app/Jackett/jackett --NoUpdates"
+fi
+
 exec \
-	s6-setuidgid abc /app/Jackett/jackett_launcher.sh "${RUN_OPTS}"
+	s6-setuidgid abc ${COMMAND} ${RUN_OPTS}

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-if [ "${AUTO_UPDATE}" == "true" ]; then
+if [ -z ${AUTO_UPDATE+x} ] || [ "${AUTO_UPDATE}" == "true" ]; then
 	COMMAND="/app/Jackett/jackett_launcher.sh"
 else
 	COMMAND="/app/Jackett/jackett --NoUpdates"

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc /app/Jackett/jackett --NoUpdates "${RUN_OPTS}"
+	s6-setuidgid abc /app/Jackett/jackett_launcher.sh "${RUN_OPTS}"


### PR DESCRIPTION
Enable auto-updates

This commit enables auto-updates. Jackett project supports more than 500 torrent indexers and we publish releases every day. Users cannot update the Docker image daily. With this change the users can deploy any Docker image and they will get fresh updates every day automatically. It's also possible to disable updates in the Jackett UI (not recommended).

@thelamer @sparklyballs I'm a Jackett developer. This PR is well tested. You have to update the changelog and update instructions in readme.