### PR TITLE
Save Docker image version in /etc/docker-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN \
 	/app/Jackett --strip-components=1 && \
  echo "**** fix for host id mapping error ****" && \
  chown -R root:root /app/Jackett && \
+ echo "**** save docker image version ****" && \
+ echo "${VERSION}" > /etc/docker-image && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -35,6 +35,8 @@ RUN \
 	/app/Jackett --strip-components=1 && \
  echo "**** fix for host id mapping error ****" && \
  chown -R root:root /app/Jackett && \
+ echo "**** save docker image version ****" && \
+ echo "${VERSION}" > /etc/docker-image && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -35,6 +35,8 @@ RUN \
 	/app/Jackett --strip-components=1 && \
  echo "**** fix for host id mapping error ****" && \
  chown -R root:root /app/Jackett && \
+ echo "**** save docker image version ****" && \
+ echo "${VERSION}" > /etc/docker-image && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \


### PR DESCRIPTION
## Description:
I'm one of the Jackett developers. This PR creates a file in `/etc/docker-image` with the Docker image version.
Since we enabled automatic updates in #102 we are having less issues, but we can't know the version of the Docker image, just the Jacket version. In some cases it's necessary to know the Docker image because some libraries like openssl are outdated.

## Benefits of this PR and context:
We are going to read that file (if it exists) and print the version near the Jackett version to help resolve issues.

## How Has This Been Tested?
Manually in my machine.
![image](https://user-images.githubusercontent.com/10577978/93025669-1cb0c080-f600-11ea-8bc2-7598a2f3bede.png)

@thelamer ping.