### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	jq \
-	libicu60 \
-	libssl1.0 \
-	wget && \
+	libicu60 && \
  echo "**** install jackett ****" && \
  mkdir -p \
 	/app/Jackett && \
@@ -42,7 +40,8 @@ RUN \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
-	/var/tmp/*
+	/var/tmp/* \
+	/var/log/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,9 +17,7 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	jq \
-	libicu60 \
-	libssl1.0 \
-	wget && \
+	libicu60 && \
  echo "**** install jackett ****" && \
  mkdir -p \
 	/app/Jackett && \
@@ -42,7 +40,8 @@ RUN \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
-	/var/tmp/*
+	/var/tmp/* \
+	/var/log/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,9 +17,7 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	jq \
-	libicu60 \
-	libssl1.0 \
-	wget && \
+	libicu60 && \
  echo "**** install jackett ****" && \
  mkdir -p \
 	/app/Jackett && \
@@ -42,7 +40,8 @@ RUN \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
-	/var/tmp/*
+	/var/tmp/* \
+	/var/log/*
 
 # add local files
 COPY root/ /


### PR DESCRIPTION

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jackett/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications


<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
* Reduce Docker image size. Removed libraries are not used and not required.

## Benefits of this PR and context:
* Image size 262 MB => 249 MB

## How Has This Been Tested?
* Tested Docker image in local with arch AMD64

## Source / References:
NOTE: I'm the main developer in Jackett.
